### PR TITLE
Return to interactive menu after invalid keypress

### DIFF
--- a/btex
+++ b/btex
@@ -19,6 +19,8 @@
         #-----------------------------------------------------------#
 
         ### MM/DD/YYYY            Changelog                       ###
+        # 02/02/2919    After invalid keypress in interactive mode, #
+        #               return to menu instead of exiting.          #
         # 02/02/2019    Re-enable Ctrl-C behavior with autocompile  #
         #               that was broken since bash-4.3!             #
         # 04/11/2015    Enable a -W switch to watch only specific   #
@@ -1565,7 +1567,8 @@ while true; do
             else    Err "$file.dvi does not exist!"
             fi ;;
     "" | [yY])  compile "$MODE" ;;
-    *)      die "$answer: Invalid Option!" ;;
+    *)      Err "$answer: Invalid option!" 
+            sleep 3;;
     esac
 
 done


### PR DESCRIPTION
This commit changes the behaviour of btex when a wrong key is pressed in the interactive menu -- i.e., a key that isn't associated to any option. Previously, btex would print an error message and exit, and it was annoying having to restart it manually. This commit makes btex show the error message for 3 seconds and then display the interactive menu again.