### PR TITLE
Fix typos introduced with the xelatex feature

### DIFF
--- a/btex
+++ b/btex
@@ -1469,7 +1469,7 @@ elif bibliography_is_present "$filename" || \
     ( [[ "$INOTIFYFILES" = "*.tex" ]] && bibliography_is_present "*.tex" \
     ); then
     info "Detected bibliography in $filename.
-    ${LaTeX##*/}/${PDFLaTeX##*/}}/${XeLaTeX##*/} will be run thrice"
+    ${LaTeX##*/}/${PDFLaTeX##*/}/${XeLaTeX##*/} will be run thrice"
     BIBLIOGRAPHY=1
     sleep "$SLEEP_TIME"
 fi

--- a/btex
+++ b/btex
@@ -547,7 +547,7 @@ parse_cmdline() {
     fi
 
     # Check for -x embedded in the command
-    if [[ "$cmd" =~ [a-np-zA-Z0-9]*x{1}.* ]]; then
+    if [[ "$cmd" =~ [a-wyzA-Z0-9]*x{1}.* ]]; then
         cmd="${cmd/x}"
         MODE="XELATEX"
     fi


### PR DESCRIPTION
Fix a typo in the info string and correct a wrong regex range used for detecting the command line option `-x` for Xelatex.